### PR TITLE
ci: remove gnu build targets

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,15 +19,9 @@ jobs:
       matrix:
         profile: ${{ github.ref_name == github.event.repository.default_branch && fromJson('["dev", "release"]') || fromJson('["dev"]') }}
         platform:
-          - target: aarch64-unknown-linux-gnu
-            os: ubuntu-22.04
-            command: cross
           - target: aarch64-unknown-linux-musl
             os: ubuntu-22.04
             command: cross
-          - target: x86_64-unknown-linux-gnu
-            os: ubuntu-22.04
-            command: cargo
           - target: x86_64-unknown-linux-musl
             os: ubuntu-22.04
             command: cargo
@@ -38,9 +32,6 @@ jobs:
             os: macos-14
             command: cargo
           - target: x86_64-pc-windows-msvc
-            os: windows-2022
-            command: cargo
-          - target: x86_64-pc-windows-gnu
             os: windows-2022
             command: cargo
     runs-on: ${{ matrix.platform.os }}


### PR DESCRIPTION
muslのほうがメモリ使用量少なかったりして、muslを避けるべき理由がない気がする。
となると、環境によっては動かないgnu版を維持する必要性が見当たらない。
